### PR TITLE
Delete command for stackl-cli

### DIFF
--- a/stackl/stackl_cli/commands/delete.py
+++ b/stackl/stackl_cli/commands/delete.py
@@ -1,0 +1,20 @@
+import json
+
+import click
+import stackl_client
+
+from context import pass_stackl_context, StacklContext
+
+
+@click.group()
+def delete():
+    pass
+
+
+@delete.command()
+@click.argument('instance-name')
+@pass_stackl_context
+def instance(stackl_context: StacklContext, instance_name):
+    res = stackl_context.stack_instances_api.delete_stack_instance(
+        instance_name)
+    click.echo(res)

--- a/stackl/stackl_cli/stackl.py
+++ b/stackl/stackl_cli/stackl.py
@@ -3,6 +3,7 @@ import click
 from commands.apply import apply
 from commands.connect import connect
 from commands.create import create
+from commands.delete import delete
 from commands.get import get
 from commands.info import info
 from commands.update import update
@@ -19,3 +20,4 @@ cli.add_command(info)
 cli.add_command(apply)
 cli.add_command(create)
 cli.add_command(update)
+cli.add_command(delete)


### PR DESCRIPTION
This adds a new option for deleting stack instances from the CLI

Fixes #40