### PR TITLE
Mount default policy in docker compose

### DIFF
--- a/build/make/prepare/templates/docker-compose.yml.j2
+++ b/build/make/prepare/templates/docker-compose.yml.j2
@@ -115,6 +115,6 @@ services:
       - "--log-format=json-pretty"
       - "--log-level=debug"
       - "--set=decision_logs.console=true"
-      {# - "--bundle /opa_files/functions" #}
+      - "/opa_files/orchestration_default_policies.rego"
     networks:
      - stackl_bridge

--- a/build/make/stackl.yml.tpl
+++ b/build/make/stackl.yml.tpl
@@ -18,4 +18,4 @@ agent_broker:
 
 opa:
   # Change this to the absolute path where your OPA files are located ##TODO: make this a fixed spot somewhere
-  opa_files_location: /home/sacs/work/stackl/stackl/application/opa_broker/opa_files
+  opa_files_location: /build/example_policies


### PR DESCRIPTION
Mounting the default policy in the docker-compose prevents it from not being there when for example opa restarts