### PR TITLE
Always put policies in OPA

### DIFF
--- a/stackl/application/handler/stack_handler.py
+++ b/stackl/application/handler/stack_handler.py
@@ -132,6 +132,11 @@ class StackHandler(Handler):
                 policy_input["policy_input"][i] = attributes[i]
             previous["services"] = opa_result['result']
             opa_data = {**previous, **policy_input}
+
+            # Make sure the policy is in OPA
+            self.opa_broker.add_policy(policy.name, policy.policy)
+
+            # And verify it
             new_result = self.opa_broker.ask_opa_policy_decision(
                 "orchestration", policy_name, opa_data)
             opa_result = {**opa_result, **new_result}

--- a/stackl/application/manager/document_manager.py
+++ b/stackl/application/manager/document_manager.py
@@ -96,7 +96,7 @@ class DocumentManager(Manager):
 
     def get_policy(self, policy_name):
         """gets a Policy from the store"""
-        store_response = self.store.get(type="policies",
+        store_response = self.store.get(type="policy",
                                         document_name=policy_name,
                                         category="configs")
         policy = Policy.parse_obj(store_response.content)

--- a/stackl/application/routers/policies_router.py
+++ b/stackl/application/routers/policies_router.py
@@ -13,7 +13,7 @@ router = APIRouter()
 document_manager = ManagerFactory().get_document_manager()
 
 
-@router.get('/{policy}', response_model=Policy)
+@router.get('/{policy_name}', response_model=Policy)
 def get_policy_by_name(policy_name: str):
     """Returns a policy"""
     try:
@@ -23,8 +23,7 @@ def get_policy_by_name(policy_name: str):
 
     if document == {}:
         raise HTTPException(status_code=StatusCode.NOT_FOUND,
-                            detail="No document with name " +
-                            policy_name)
+                            detail="No document with name " + policy_name)
     logger.debug(f"[DocumentsByType GET] document(s): {document}")
     return document
 

--- a/stackl/stackl_cli/commands/create.py
+++ b/stackl/stackl_cli/commands/create.py
@@ -38,6 +38,8 @@ def instance(stackl_context: StacklContext, stack_infrastructure_template,
 def policy(stackl_context: StacklContext, policy_file, policy_name, inputs):
     inputs = [i.strip() for i in inputs.split(',')]
     policy = stackl_client.Policy(name=policy_name,
+                                  type="policy",
+                                  category="configs",
                                   description="policy through cli",
                                   policy=policy_file.read(),
                                   inputs=inputs)


### PR DESCRIPTION
This change makes sure that OPA will always have the needed policy
by pushing it to OPA before evaluating it