### PR TITLE
Add flag for force deleting stack instances

### DIFF
--- a/stackl/cli/commands/delete.py
+++ b/stackl/cli/commands/delete.py
@@ -11,10 +11,11 @@ def delete(ctx):
 
 @delete.command()
 @click.argument('instance-name')
+@click.option('--force', default=False, is_flag=True)
 @pass_stackl_context
-def instance(stackl_context: StacklContext, instance_name):
+def instance(stackl_context: StacklContext, instance_name, force):
     res = stackl_context.stack_instances_api.delete_stack_instance(
-        instance_name)
+        instance_name, force=force)
     click.echo(res)
 
 

--- a/stackl/core/core/agent_broker/agent_task_broker.py
+++ b/stackl/core/core/agent_broker/agent_task_broker.py
@@ -11,7 +11,7 @@ async def create_job_for_agent(stack_instance,
                                action,
                                document_manager,
                                redis,
-                               first_run=True):
+                               first_run=True, force_delete=False):
     logger.debug(
         f"[AgentTaskBroker] create_job_for_agent. For stack_instance '{stack_instance}' and action '{action}'"
     )
@@ -72,11 +72,11 @@ async def create_job_for_agent(stack_instance,
 
             if not success:
                 logger.debug("Not all fr's succeeded, stopping execution")
-                return
+                break
 
             logger.debug(f"tasks executed")
 
-    if success and action == "delete":
+    if action == "delete" and (success or force_delete):
         document_manager.delete_stack_instance(stack_instance.name)
     elif not success and first_run:
         snapshot_document = get_snapshot_manager().restore_latest_snapshot(

--- a/stackl/core/core/routers/stack_instances_router.py
+++ b/stackl/core/core/routers/stack_instances_router.py
@@ -135,12 +135,12 @@ async def put_stack_instance(
 def delete_stack_instance(
     name: str,
     background_tasks: BackgroundTasks,
+    force: bool = False,
     document_manager: DocumentManager = Depends(get_document_manager),
     redis=Depends(get_redis)):
     """Delete a stack instance with a specific name"""
     stack_instance = document_manager.get_stack_instance(name)
-
     background_tasks.add_task(create_job_for_agent, stack_instance, "delete",
-                              document_manager, redis)
+                              document_manager, redis, force_delete=force)
 
     return {"result": f"Deleting stack instance {name}"}


### PR DESCRIPTION
Sometimes users wanted to just delete a stack instance and it would be
okay if the automation for deleting one failed. With this commit there is
the option of providing the option to force delete it from stackl.

Fixes #146