### PR TITLE
Add option to configure max_jobs

### DIFF
--- a/stackl/agent/agent/config.py
+++ b/stackl/agent/agent/config.py
@@ -10,6 +10,7 @@ class Settings(BaseSettings):
     redis_port: int = 6379
     secret_handler: str = "base64"
     loglevel: str = "INFO"
+    max_jobs: int = 10
 
     # Kubernetes Handler
     stackl_namespace: str = None

--- a/stackl/agent/agent/main.py
+++ b/stackl/agent/agent/main.py
@@ -56,5 +56,6 @@ async def invoke_automation(ctx, invoc):
 class AgentSettings:
     functions = [invoke_automation]
     queue_name = config.settings.agent_name
+    max_jobs = config.settings.max_jobs
     redis_settings = RedisSettings(host=config.settings.redis_host,
                                    port=config.settings.redis_port)


### PR DESCRIPTION
Max jobs that run per agent can be set with the MAX_JOBS env variable
defaults to 10

Fixes #148