### PR TITLE
Add exit code 1 on failure

### DIFF
--- a/stackl/cli/commands/apply.py
+++ b/stackl/cli/commands/apply.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import click
 import stackl_client
 import yaml
+from sys import exit
 from context import StacklContext
 from mergedeep import merge
 
@@ -107,3 +108,4 @@ def upload_files(directory, stackl_context):
                 click.echo(
                     f"Failed to apply {stackl_doc['name']} with type {stackl_doc['type']}: {e.body}"
                 )
+                exit(1)


### PR DESCRIPTION
Fixes #153 

Tried with:

```yaml
category: configs
description: example-playbook
invocation:
  description: Example playbook
  image: stacklio/example-playbook:v1.0.0
  tool: ansible
name: example-playbook
params:
  ansible_playbook_path: /opt/ansible/playbook.yml
type: functional_requirement
```

Result:

```bash
bash-4.4# stackl apply -d .
Reading document: fr.yml
Applying stackl document: fr.yml example-playbook
Failed to apply example-playbook with type functional_requirement: {"detail":[{"loc":["body","document","invocation","description"],"msg":"value is not a valid dict","type":"type_error.dict"},{"loc":["body","document","invocation","image"],"msg":"value is not a valid dict","type":"type_error.dict"},{"loc":["body","document","invocation","tool"],"msg":"value is not a valid dict","type":"type_error.dict"}]}
bash-4.4# echo $?
1
```