### PR TITLE
Use intercepthandler for uvicorn logs

### DIFF
--- a/docs/content/basic/configuration.md
+++ b/docs/content/basic/configuration.md
@@ -15,7 +15,7 @@ The following environment variables can be set for the stackl-core:
 
 | Parameter | Description | Default |
 |------------|------|------|
-| `LOGLEVEL` | Set the loglevel | INFO |
+| `LOG_LEVEL` | Set the loglevel | INFO |
 | `STACKL_STORE` | Set the type of stackl store options: Redis/LFS | Redis |
 | `STACKL_DATASTORE_PATH` | Path where to safe the stackl documents, only used when `STACKL_STORE` is `LFS` | /lfs-store |
 | `STACKL_REDIS_TYPE` | Set the redis type, only change this to `false` for testing | real |

--- a/stackl/core/core/config.py
+++ b/stackl/core/core/config.py
@@ -1,13 +1,40 @@
 """
 Config module used for configuration data of stackl core
 """
+import logging
+
+from loguru import logger
 from pydantic import BaseSettings
 
 
-class Settings(BaseSettings): # pylint: disable=too-few-public-methods
+class InterceptHandler(logging.Handler):
+    """
+    Default handler from examples in loguru documentaion. see
+    https://loguru.readthedocs.io/en/stable/overview.html#entirely-compatible-with-standard-logging
+    """
+    def emit(self, record):
+        # Get corresponding Loguru level if it exists
+        try:
+            level = logger.level(record.levelname).name
+        except ValueError:
+            level = record.levelno
+
+        # Find caller from where originated the logged message
+        frame, depth = logging.currentframe(), 2
+        while frame.f_code.co_filename == logging.__file__:
+            frame = frame.f_back
+            depth += 1
+
+        logger.opt(depth=depth,
+                   exception=record.exc_info).log(level, record.getMessage())
+
+
+class Settings(BaseSettings):  # pylint: disable=too-few-public-methods
     """
     Class containing all settings applicable to core component
     """
+    log_level: str = "DEBUG"
+
     # Datastore options
     stackl_store: str = "Redis"
     stackl_datastore_path: str = "/lfs-store"
@@ -26,5 +53,6 @@ class Settings(BaseSettings): # pylint: disable=too-few-public-methods
 
     # Elastic APM options
     elastic_apm_enabled: bool = False
+
 
 settings = Settings()

--- a/stackl/core/core/main.py
+++ b/stackl/core/core/main.py
@@ -6,28 +6,37 @@ try:
 except ImportError:
     import importlib_metadata as metadata
 
+import logging
+import sys
+
 import uvicorn
-from elasticapm.contrib.starlette import make_apm_client, ElasticAPM
+from elasticapm.contrib.starlette import ElasticAPM, make_apm_client
 from fastapi import FastAPI
 from fastapi.routing import APIRoute
 # Logger stuff
 from loguru import logger
 
 from core import config
-from .routers import functional_requirements_router, infrastructure_base_router, \
-    policy_templates_router, snapshots_router, stack_instances_router, \
-    services_router, stack_application_templates_router, \
-    stack_infrastructure_templates_router, about_router, outputs_router
+
+from .routers import (about_router, functional_requirements_router,
+                      infrastructure_base_router, outputs_router,
+                      policy_templates_router, services_router,
+                      snapshots_router, stack_application_templates_router,
+                      stack_infrastructure_templates_router,
+                      stack_instances_router)
+
+logging.getLogger().handlers = [config.InterceptHandler()]
+logging.getLogger("uvicorn.access").handlers = [config.InterceptHandler()]
+
+logger.configure(handlers=[{"sink": sys.stderr, "level": config.settings.log_level}])
 
 logger.info(
     "___________________ STARTING STACKL API SERVER ____________________")
 
 # Add routes
-app = FastAPI(
-    title="STACKL",
-    description="stackl",
-    version=metadata.version('core')
-)
+app = FastAPI(title="STACKL",
+              description="stackl",
+              version=metadata.version('core'))
 
 if config.settings.elastic_apm_enabled:
     logger.debug("Elastic APM Enabled")


### PR DESCRIPTION
Uvicorn logs were using their own handler. We wanted all logs to
go through loguru. The loglevel can also be set now using LOG_LEVEL env
variable.

Fixes #167