### PR TITLE
Fix update infra capabilities

### DIFF
--- a/stackl/core/core/handler/stack_handler.py
+++ b/stackl/core/core/handler/stack_handler.py
@@ -588,9 +588,11 @@ class StackHandler(Handler):
         stack_infrastructure_template = self.document_manager.get_stack_infrastructure_template(
             stack_instance.stack_infrastructure_template)
 
+        stack_infr = self._update_infr_capabilities(stack_infrastructure_template, "yes")
+
         # Transform to OPA format
         opa_data = self.transform_opa_data(item, stack_application_template,
-                                           stack_infrastructure_template)
+                                           stack_infr)
 
         opa_solution = self.evaluate_orchestration_policy(opa_data)
 


### PR DESCRIPTION
This fix solves an issue where infra capabilities for a sit were empty and not updated when a stack instance was updated, which resulted in OPA not finding a target for the instance.