### PR TITLE
Wait for all containers in a Stackl job pod to be ready

### DIFF
--- a/stackl/agent/agent/kubernetes/handlers/base_handler.py
+++ b/stackl/agent/agent/kubernetes/handlers/base_handler.py
@@ -332,16 +332,17 @@ class Handler(ABC):
                 if error:
                     return False, msg, init_cs.name
             # Check container statuses
+            containers_ready = True
             for cs in api_response.status.container_statuses:
                 error, msg = check_container_status(cs)
                 if error:
                     return False, msg, cs.name
-                if cs.state.waiting is None and \
-                    cs.state.running is None and  \
-                    cs.state.terminated is not None and \
-                    cs.state.terminated.reason == 'Completed' and \
-                    cs.name == "jobcontainer":
-                    return True, "", cs.name
+                if cs.state.terminated is not None or \
+                    cs.state.terminated.reason != 'Completed':
+                    containers_ready = False
+            if containers_ready:
+                return True, "", None
+
 
     def handle(self):
         """


### PR DESCRIPTION
There was a problem when using outputs that a job would be marked
as ready, but it could have been that the outputs container was still
running and processing outputs, with this change we wait for every container
to be finished and completed

Fixes #189