### PR TITLE
Catch glom error

### DIFF
--- a/stackl/cli/scripts/convert_json_from_spec.py
+++ b/stackl/cli/scripts/convert_json_from_spec.py
@@ -6,6 +6,7 @@ from abc import ABC, abstractmethod
 from collections import defaultdict
 
 from glom import glom
+from glom.core import PathAccessError
 
 
 class Converter(ABC):
@@ -48,7 +49,10 @@ class JsonConverter(Converter):
     def convert(self):
         result = {}
         for field_name, field_spec in self.json_spec.items():
-            result[field_name] = glom(self.json_doc, field_spec)
+            try:
+                result[field_name] = glom(self.json_doc, field_spec)
+            except PathAccessError as e:
+                result[field_name] = None
         return result
 
 


### PR DESCRIPTION
When an output is not available it should still work, since FR's can output different values depending on their params.
We now catch the Glom error when a value isn't found and set the output to None