### PR TITLE
WIP redis sentinel

### DIFF
--- a/stackl/agent/agent/config.py
+++ b/stackl/agent/agent/config.py
@@ -8,6 +8,7 @@ except ImportError:
     import importlib_metadata as metadata
 
 from pydantic import BaseSettings
+from typing import List, Tuple, Union
 
 
 class Settings(BaseSettings):
@@ -18,9 +19,11 @@ class Settings(BaseSettings):
     stackl_host: str = "http://localhost:8000"
     agent_name: str = "common"
     agent_type: str = "mock"
-    redis_host: str = "localhost"
+    redis_host: List[Tuple[str, int]] = '[["localhost", 26379]]'
     redis_port: int = 6379
     redis_password: str = None
+    redis_sentinel: bool = False
+    redis_sentinel_master: str = ""
     secret_handler: str = "base64"
     loglevel: str = "INFO"
     max_jobs: int = 10

--- a/stackl/agent/agent/main.py
+++ b/stackl/agent/agent/main.py
@@ -86,5 +86,6 @@ class AgentSettings:
     job_timeout = config.settings.job_timeout
     max_jobs = config.settings.max_jobs
     redis_settings = RedisSettings(host=config.settings.redis_host,
-                                   port=config.settings.redis_port,
-                                   password=config.settings.redis_password)
+                                   password=config.settings.redis_password,
+                                   sentinel_master=config.settings.redis_sentinel_master,
+                                   sentinel=config.settings.redis_sentinel)


### PR DESCRIPTION
# Description of feature 

Support for redis sentinel

# Additional information

So far added `redis_host` has a list of tuples, just like in [arq](https://github.com/samuelcolvin/arq/blob/master/arq/connections.py#L41). 
Attempted to use a Union of tuples and str, but when I did it always parsed the conf through the environment as a string.
